### PR TITLE
'Git 100% 활용하기', '코드리뷰, GitHub로 바로 적용하기' URL 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@
 * [코드 리뷰, 5가지만 기억하자](http://silentsoft.tistory.com/20)
 * [깃헙을 통한 코드리뷰](http://ohgyun.com/367)
 * [Gerrit을 이용한 코드 리뷰 시스템](http://d2.naver.com/helloworld/6033708)
-* [코드리뷰, GitHub로 바로 적용하기](https://news.realm.io/kr/news/codereview-howto/)
+* [코드리뷰, GitHub로 바로 적용하기](https://academy.realm.io/kr/posts/codereview-howto/)
 * [카카오스토리 팀의 코드 리뷰 도입 사례 - 코드 리뷰, 어디까지 해봤니?](http://tech.kakao.com/2016/02/04/code-review/)
 * [1000개의 코드 리뷰를 통해 배운점](https://www.vobour.com/1000-개의-코드-리뷰를-통해-배운-점-what-i-learned-f)
 * [효과적인 코드 리뷰를 위해서](https://engineering.linecorp.com/ko/blog/effective-codereview/?fbclid=IwAR06sz07ZCaEKqtoeT0s_YRdXw5OhiLRxDgK8gVldpCJVl3GP_Txe6WJRro)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@
 * [우아한 형제들 이야기](http://woowabros.github.io/woowabros/2016/06/30/woowabros_cto.html)
 * [토스랩 이야기 1](http://www.slideshare.net/ssuser70b5b8/ss-58709101)
 * [토스랩 이야기 2](http://www.slideshare.net/ssuser70b5b8/ss-66617364)
-* [Git 100% 활용하기](https://realm.io/kr/news/360andev-savvas-dalkitsis-using-git-like-a-pro/)
+* [Git 100% 활용하기](https://academy.realm.io/kr/posts/360andev-savvas-dalkitsis-using-git-like-a-pro/)
 * [성공적으로 재택 근무 시스템을 도입하는 방법](http://ppss.kr/archives/88997)
 * [Toss 기업문화](https://tossthink.tistory.com/89)
 * [스타트업에서 스크럼 잘하기](https://www.slideshare.net/yonghoon0126/ss-72605097)


### PR DESCRIPTION
'Git 100% 활용하기' 와 '코드리뷰, GitHub로 바로 적용하기' 글의 URL이 더이상 유효하지 않아서 수정합니다.
