### PR TITLE
토스 관련된 글이 삭제되어 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,6 @@
 * [심리적 안정감, 성공적인 성과를 만드는 팀의 필수조건](https://www.slideshare.net/haezoom/ss-76096152)
 * [회사에서 새로운 기술_적용하기](https://www.slideshare.net/junseokjung1/ss-76115779)
 * [스포티파이에서는 결정권자가 누구인지 아무도 신경쓰지 않는다](https://hahnryu.com/2017/06/15/spotify/)
-* [토스 핵심 가치](http://tossthink.tistory.com/178)
-* [토스팀의 문화 소개](http://tossthink.tistory.com/179)
 * [사고를 쳐도 혼나지 않는 회사](https://brunch.co.kr/@svillustrated/13)
 * [조직이 성장하는 법 – 문화와 시스템](https://medium.com/kimjimin-company/조직이-성장하는-법-문화와-시스템-db7730febc8)
 * [왜 엔지니어링 블로그를 운영해야할까?](https://medium.com/styleshare/styleshare-engineering-blog-c4ae14d49cf4)


### PR DESCRIPTION
`http://tossthink.tistory.com` 해당 블로그가 광고 블로그로 변경되었네요!

수정 PR드립니다.