### PR TITLE
yona 데모 운영 중지로 관련 링크 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
 
 ## 채용
 
-* [[면접팁] 좋은 면접자/지원자를 뽑고 싶은 회사와 면접관에 대한 이런저런 생각들](https://repo.yona.io/doortts/blog/post/295)
 * [능력있는 개발자는 어떻게 알아볼 수 있나?](https://docs.google.com/document/d/1_phA5XUszSmN7Ta-QHs4DxRz9_iu8YlhxpVjSGEbWcg/edit)
 * [스타트업 면접 후기와 꿀팁](https://brunch.co.kr/@bradlee/39)
 * [슬로워크 입사지원서 설계 이야기](http://slowalk.tistory.com/2382)


### PR DESCRIPTION
안녕하세요~
자료를 모아주신 덕분에 많은 도움을 받고 있습니다

자료를 보던 중에 링크로 걸려있던 https://repo.yona.io 사이트가 2023년 6월 30일부로 운영이 종료된 것을 발견하여
관련 링크를 제거했습니다

다행히? 관련 링크가 하나만 있었네요


원본을 찾아서 제안드리고 싶었는데
원본의 주인이 yona라는 사이트에 애초에 글을 올린 것 같습니다 😢
```
https:// `doortts` .tistory.com/291 // 같은 제목 다른 블로그
https://repo.yona.io/ `doortts` /blog/post/295 // 삭제된 링크
```